### PR TITLE
Right way to declare curl lib dependency

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -15,8 +15,8 @@
                 "NativeCall",
                 "NativeLibs:ver<0.0.7>:auth<github:salortiz>",
                 "JSON::Fast",
-                "curl:from<native>"
-            ]
+                "curl:from<native>:ver<4>"
+             ]
         },
         "test": {
             "requires": [ "Test", "Test::When" ]


### PR DESCRIPTION
Hi @CurtTilmes ! According a discussion has been taken here - https://github.com/ugexe/zef/issues/356  I am suggesting a right way to declare libcurl dependencies.

Please compare these two builds:

* FAILS - http://rakudist.raku.org/sparky/report/centos/407
* PASS - http://rakudist.raku.org/sparky/report/centos/410 

zef check fails in the first one:

```
17:29:17 06/25/2020 [bash: zef install LibCurl] ===> Failed to find dependencies: curl:from<native>
```

because NativeCall semantic check is guaranteed when one specify version for dependency, not just a library name

cc @ugexe @niner  