### PR TITLE
That version is no longer available in the ecosystem

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -13,7 +13,7 @@
         "runtime": {
             "requires": [
                 "NativeCall",
-                "NativeLibs:ver<0.0.7>:auth<github:salortiz>",
+                "NativeLibs:ver<0.0.7+>:auth<github:salortiz>",
                 "JSON::Fast",
                 "curl:from<native>:ver<4>"
              ]


### PR DESCRIPTION
It will probably work just as well with anyone newer than that.