### PR TITLE
Fix extraction of charset from content-type header

### DIFF
--- a/lib/LibCurl/Easy.rakumod
+++ b/lib/LibCurl/Easy.rakumod
@@ -468,7 +468,7 @@ class LibCurl::Easy
         with self.receiveheaders<content-type>
         {
             # Should be a stricter grammar, but dump regex will work for now
-            if /charset \s* '=' \s* \\? <['"]>? (<-[\\"']>*) \\? <['"]>? /
+            if /charset \s* '=' \s* \\? <['"]>? (<-[\\";']>*) \\? <['"]>? /
             {
                 $encoding = $0.Str;
             }


### PR DESCRIPTION
Hi Curt,

If a  `Content-Type` header has something like `charset=utf-8;header=present` then the current regex doesn't stop at the `;` when looking for the charset -- here's a little fix for that :-)

all the best
Brian
