### PR TITLE
Fix cleanup method

### DIFF
--- a/lib/LibCurl/Easy.rakumod
+++ b/lib/LibCurl/Easy.rakumod
@@ -750,7 +750,6 @@ class LibCurl::Easy
         $allhandles-lock.protect({ %allhandles{$!handle.id}:delete });
         .cleanup with $!handle;
         $!handle = LibCurl::EasyHandle;
-        self.clear-form;
         .free for @!slists;
         @!slists = ();
     }

--- a/lib/LibCurl/EasyHandle.rakumod
+++ b/lib/LibCurl/EasyHandle.rakumod
@@ -814,7 +814,7 @@ class LibCurl::EasyHandle is repr('CPointer')
     method new() returns LibCurl::EasyHandle { curl_easy_init }
 
     method id() returns Int {
-        return +nativecast(Pointer, self);
+        return +( nativecast(Pointer, self) // -1);
     }
 
     method cleanup() { curl_easy_cleanup(self) }


### PR DESCRIPTION
This fixes the `.cleanup` method by removing the call to the non-existent `clear-form` method. (resolves #26)

Also fixes the error below which seems to occur sometimes when calling cleanup:

```
Invocant of method 'Numeric' must be an object instance of type
'NativeCall::Types::Pointer', not a type object of type
'NativeCall::Types::Pointer'.  Did you forget a '.new'?
  in method Numeric at /Users/bduggan/.rakubrew/versions/moar-2021.04/share/perl6/core/sources/8660F65A7B3492675BB3B2058DB30E411A4C4E54 (NativeCall::Types) line 31
  in method id at /Users/bduggan/raku-libcurl/lib/LibCurl/EasyHandle.rakumod (LibCurl::EasyHandle) line 817
  in method cleanup at /Users/bduggan/raku-libcurl/lib/LibCurl/Easy.rakumod (LibCurl::Easy) line 750
  in submethod DESTROY at /Users/bduggan/raku-libcurl/lib/LibCurl/Easy.rakumod (LibCurl::Easy) line 759
...
```